### PR TITLE
Add config directory

### DIFF
--- a/basedir.go
+++ b/basedir.go
@@ -19,6 +19,11 @@ func Data() string {
 	return data()
 }
 
+// Config returns the base config directory.
+func Config() string {
+	return config()
+}
+
 func firstGetenv(def string, evs ...string) string {
 	for _, ev := range evs {
 		if v := os.Getenv(ev); v != "" {

--- a/basedir_darwin.go
+++ b/basedir_darwin.go
@@ -6,6 +6,7 @@ package basedir
 var (
 	cacheDir = firstGetenv("Library/Caches")
 	dataDir  = firstGetenv("Library/Application Support")
+	configDir  = firstGetenv("Library/Preferences")
 )
 
 func cache() string {
@@ -14,4 +15,8 @@ func cache() string {
 
 func data() string {
 	return dataDir
+}
+
+func config() string {
+	return configDir
 }

--- a/basedir_unix.go
+++ b/basedir_unix.go
@@ -7,7 +7,8 @@ package basedir
 
 var (
 	cacheDir = firstGetenv(".cache", "XDG_CACHE_HOME")
-	dataDir  = firstGetenv(".config", "XDG_CONFIG_HOME")
+	dataDir  = firstGetenv(".local/share", "XDG_DATA_HOME")
+	configDir  = firstGetenv(".config", "XDG_CONFIG_HOME")
 )
 
 func cache() string {
@@ -16,4 +17,8 @@ func cache() string {
 
 func data() string {
 	return dataDir
+}
+
+func config() string {
+	return configDir
 }

--- a/basedir_windows.go
+++ b/basedir_windows.go
@@ -6,6 +6,7 @@ package basedir
 var (
 	cacheDir = firstGetenv("", "TEMP", "TMP")
 	dataDir  = firstGetenv("", "APPDATA")
+	configDir  = firstGetenv("", "APPDATA")
 )
 
 func cache() string {
@@ -14,4 +15,8 @@ func cache() string {
 
 func data() string {
 	return dataDir
+}
+
+func config() string {
+	return configDir
 }


### PR DESCRIPTION
I've added a Config function to return XDG_CONFIG_HOME on Linux, Library/Preferences on macOS and APPDATA for Windows.

Warning this breaks compatibility on the Unix dataDir as it was originally mapped to .config, and now it's .local/share / XDG_DATA_HOME.